### PR TITLE
Add CI pipeline and initial tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm run build --if-present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1.ts'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "node build/index.js",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
-    "test": "vitest run"
+    "test": "jest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.6.0",
@@ -27,6 +27,8 @@
   "devDependencies": {
     "@types/node": "^20.11.24",
     "typescript": "^5.3.3",
-    "vitest": "^1.5.0"
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "prepare": "npm run build",
     "start": "node build/index.js",
     "watch": "tsc --watch",
-    "inspector": "npx @modelcontextprotocol/inspector build/index.js"
+    "inspector": "npx @modelcontextprotocol/inspector build/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.6.0",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.24",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "vitest": "^1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "open": "^10.1.2"
   },
   "devDependencies": {
-    "@types/node": "^20.11.24",
+    "@types/node": "^22.0.0",
     "typescript": "^5.3.3",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+export interface EtsyConfig {
+  apiKey: string;
+  sharedSecret: string;
+  refreshToken: string;
+}
+
+export function loadEtsyConfig(): EtsyConfig {
+  let apiKey: string | undefined = process.env.ETSY_API_KEY;
+  let sharedSecret: string | undefined = process.env.ETSY_SHARED_SECRET;
+  let refreshToken: string | undefined = process.env.ETSY_REFRESH_TOKEN;
+
+  if (!apiKey || !sharedSecret || !refreshToken) {
+    try {
+      const __dirname = path.dirname(fileURLToPath(import.meta.url));
+      const settingsPath = path.join(__dirname, '..', 'cline_mcp_settings.json');
+      const raw = fs.readFileSync(settingsPath, 'utf-8');
+      const cfg = JSON.parse(raw)["etsy-mcp-server"] ?? {};
+      apiKey = apiKey || cfg.keystring;
+      sharedSecret = sharedSecret || cfg.sharedSecret;
+      refreshToken = refreshToken || cfg.refreshToken;
+    } catch {
+      // ignore – handled below if still undefined
+    }
+  }
+
+  if (!apiKey || !sharedSecret || !refreshToken) {
+    throw new Error(
+      'ETSY_API_KEY, ETSY_SHARED_SECRET, and ETSY_REFRESH_TOKEN environment variables are required'
+    );
+  }
+
+  return {
+    apiKey,
+    sharedSecret,
+    refreshToken,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,32 +8,13 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import axios from 'axios';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { loadEtsyConfig } from './config.js';
 
-let API_KEY: string | undefined = process.env.ETSY_API_KEY;
-let SHARED_SECRET: string | undefined = process.env.ETSY_SHARED_SECRET;
-let REFRESH_TOKEN: string | undefined = process.env.ETSY_REFRESH_TOKEN;
-
-if (!API_KEY || !SHARED_SECRET || !REFRESH_TOKEN) {
-  // Attempt to load from cline_mcp_settings.json in project root
-  try {
-    const __dirname = path.dirname(fileURLToPath(import.meta.url));
-    const settingsPath = path.join(__dirname, '..', 'cline_mcp_settings.json');
-    const raw = fs.readFileSync(settingsPath, 'utf-8');
-    const cfg = JSON.parse(raw)["etsy-mcp-server"] ?? {};
-    API_KEY = API_KEY || cfg.keystring;
-    SHARED_SECRET = SHARED_SECRET || cfg.sharedSecret;
-    REFRESH_TOKEN = REFRESH_TOKEN || cfg.refreshToken;
-  } catch {
-    // ignore – handled below if still undefined
-  }
-}
-
-if (!API_KEY || !SHARED_SECRET || !REFRESH_TOKEN) {
-  throw new Error('ETSY_API_KEY, ETSY_SHARED_SECRET, and ETSY_REFRESH_TOKEN environment variables are required');
-}
+const {
+  apiKey: API_KEY,
+  sharedSecret: SHARED_SECRET,
+  refreshToken: REFRESH_TOKEN,
+} = loadEtsyConfig();
 
 class EtsyServer {
   private server: Server;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 import { loadEtsyConfig } from '../src/config.js';

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { loadEtsyConfig } from '../src/config.js';
+
+const settingsPath = path.join(__dirname, '..', 'cline_mcp_settings.json');
+
+function cleanup() {
+  if (fs.existsSync(settingsPath)) {
+    fs.unlinkSync(settingsPath);
+  }
+}
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  cleanup();
+});
+
+describe('loadEtsyConfig', () => {
+  it('uses environment variables when set', () => {
+    process.env.ETSY_API_KEY = 'key';
+    process.env.ETSY_SHARED_SECRET = 'secret';
+    process.env.ETSY_REFRESH_TOKEN = 'token';
+    const cfg = loadEtsyConfig();
+    expect(cfg).toEqual({ apiKey: 'key', sharedSecret: 'secret', refreshToken: 'token' });
+  });
+
+  it('reads from config file when env vars missing', () => {
+    const data = {
+      'etsy-mcp-server': {
+        keystring: 'k',
+        sharedSecret: 's',
+        refreshToken: 'r',
+      },
+    };
+    fs.writeFileSync(settingsPath, JSON.stringify(data));
+    delete process.env.ETSY_API_KEY;
+    delete process.env.ETSY_SHARED_SECRET;
+    delete process.env.ETSY_REFRESH_TOKEN;
+    const cfg = loadEtsyConfig();
+    expect(cfg).toEqual({ apiKey: 'k', sharedSecret: 's', refreshToken: 'r' });
+  });
+
+  it('throws if config missing', () => {
+    delete process.env.ETSY_API_KEY;
+    delete process.env.ETSY_SHARED_SECRET;
+    delete process.env.ETSY_REFRESH_TOKEN;
+    expect(() => loadEtsyConfig()).toThrowError(
+      'ETSY_API_KEY, ETSY_SHARED_SECRET, and ETSY_REFRESH_TOKEN environment variables are required'
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vitest/config';
-
-export default defineConfig({
-  test: {
-    environment: 'node',
-  },
-});


### PR DESCRIPTION
## Summary
- create reusable config loader
- integrate config loader into server
- add basic unit tests with Vitest
- configure GitHub Actions for CI

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685d877426ec8331ab768c46d2b54bc5