### PR TITLE
Add shop section endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Update an existing listing. Requires `shop_id` and `listing_id`. Optional fields
 ### `getShopReceipts`
 Retrieve receipts for a shop. Requires `shop_id`.
 
+### `getShopSections`
+Retrieve the list of sections in a shop. Requires `shop_id`.
+
+### `getShopSection`
+Retrieve a single shop section by `shop_id` and `shop_section_id`.
+
 ## Debugging
 
 The server communicates over stdio. For debugging you can launch it with the MCP Inspector:

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,6 @@ export default {
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
-    '^(\\.{1,2}/.*)\\.js$': '$1.ts'
+    '^(\\.{1,2}/src/.*)\\.js$': '$1.ts'
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,29 @@ class EtsyServer {
                 },
                 required: ['shop_id'],
             },
+        },
+        {
+            name: 'getShopSections',
+            description: 'Get sections for a shop',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    shop_id: { type: 'string', description: 'The ID of the shop' },
+                },
+                required: ['shop_id'],
+            },
+        },
+        {
+            name: 'getShopSection',
+            description: 'Get a single shop section',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    shop_id: { type: 'string', description: 'The ID of the shop' },
+                    shop_section_id: { type: 'string', description: 'The ID of the shop section' },
+                },
+                required: ['shop_id', 'shop_section_id'],
+            },
         }
       ],
     }));
@@ -253,6 +276,12 @@ class EtsyServer {
             break;
           case 'getShopPolicies':
             response = await this.axiosInstance.get(`/application/shops/${request.params.arguments.shop_id}/policies`);
+            break;
+          case 'getShopSections':
+            response = await this.axiosInstance.get(`/application/shops/${request.params.arguments.shop_id}/sections`);
+            break;
+          case 'getShopSection':
+            response = await this.axiosInstance.get(`/application/shops/${request.params.arguments.shop_id}/sections/${request.params.arguments.shop_section_id}`);
             break;
           default:
             throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${request.params.name}`);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, afterEach } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { loadEtsyConfig } from '../src/config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const settingsPath = path.join(__dirname, '..', 'cline_mcp_settings.json');
 


### PR DESCRIPTION
## Summary
- add tools for `getShopSections` and `getShopSection`
- document the new tools in the README
- tweak Jest config and tests for ESM

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dbc8ba37c8331804a8ef43a9b48f9