### PR TITLE
Add seller taxonomy endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Retrieve the list of sections in a shop. Requires `shop_id`.
 ### `getShopSection`
 Retrieve a single shop section by `shop_id` and `shop_section_id`.
 
+### `getSellerTaxonomyNodes`
+Retrieve the full hierarchy of seller taxonomy nodes.
+
+### `getPropertiesByTaxonomyId`
+List product properties supported for a specific taxonomy node. Requires `taxonomy_id`.
+
 ## Debugging
 
 The server communicates over stdio. For debugging you can launch it with the MCP Inspector:

--- a/src/handlers/seller-taxonomy.ts
+++ b/src/handlers/seller-taxonomy.ts
@@ -1,0 +1,31 @@
+import { AxiosInstance } from 'axios';
+
+export const tools = [
+  {
+    name: 'getSellerTaxonomyNodes',
+    description: 'Retrieve the full hierarchy tree of seller taxonomy nodes',
+    inputSchema: { type: 'object', properties: {} }
+  },
+  {
+    name: 'getPropertiesByTaxonomyId',
+    description: 'Get product properties supported for a specific taxonomy ID',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        taxonomy_id: {
+          type: 'string',
+          description: 'The seller taxonomy node ID'
+        }
+      },
+      required: ['taxonomy_id']
+    }
+  }
+];
+
+export const handlers: Record<string, (args: any, axios: AxiosInstance) => Promise<any>> = {
+  getSellerTaxonomyNodes: async (_args, axios) =>
+    axios.get('/application/seller-taxonomy/nodes'),
+
+  getPropertiesByTaxonomyId: async (args, axios) =>
+    axios.get(`/application/seller-taxonomy/nodes/${args.taxonomy_id}/properties`)
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 import axios from 'axios';
 import { tools as shopTools, handlers as shopHandlers } from './handlers/shop.js';
 import { tools as listingTools, handlers as listingHandlers } from './handlers/listing.js';
+import { tools as sellerTaxonomyTools, handlers as sellerTaxonomyHandlers } from './handlers/seller-taxonomy.js';
 import { loadEtsyConfig } from './config.js';
 
 const {
@@ -74,10 +75,11 @@ class EtsyServer {
 
 
   private setupToolHandlers() {
-    const allTools = [...shopTools, ...listingTools];
+    const allTools = [...shopTools, ...listingTools, ...sellerTaxonomyTools];
     const handlers = {
       ...shopHandlers,
       ...listingHandlers,
+      ...sellerTaxonomyHandlers,
     } as Record<string, (args: any, axios: any) => Promise<any>>;
 
     this.server.setRequestHandler(ListToolsRequestSchema, async () => ({


### PR DESCRIPTION
## Summary
- implement seller taxonomy tools
- expose them from the server
- document new tools in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9214373883318bc16faeb1b6f00c